### PR TITLE
Allow for spaces in file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,8 +119,8 @@ function glue(dest,options) {
         }
         if (file.isDirectory()) {
             var command = ['glue'];
-            command.push(file.path);
-            command.push(dest);
+            command.push('"'+file.path+'"');
+            command.push('"'+dest+'"');
             command = command.concat(commandOptions);
 
             console.log('Execute: ' + command.join(' '));


### PR DESCRIPTION
Fixes a bug that would cause Glue to throw an error if spaces present in either the source or destination file paths.
