### PR TITLE
Respect quiet option

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ function glue(dest,options) {
         dest = null;
     }
 
-    var commandOptions = [];
+    var commandOptions = [],
+        quiet = false;
 
     if (options) {
         if (options.cmd) {
@@ -68,6 +69,9 @@ function glue(dest,options) {
         } else {
             //プロパティ見てオプションコマンドの追加
             for (var key in options) {
+                if (key === 'quiet' && options[key]) {
+                    quiet = true;
+                }
                 var v = parseOption(key, options[key]);
                 if (v) {
                     commandOptions.push(v);
@@ -89,9 +93,13 @@ function glue(dest,options) {
             }
             command = command.concat(commandOptions);
 
-            gutil.log('Execute: ' + command.join(' '));
+            if (!quiet) {
+                gutil.log('Execute: ' + command.join(' '));
+            }
             exec(command.join(' '), function (err, stdout, stderr) {
-                console.log(stdout);
+                if (!quiet) {
+                    console.log(stdout);
+                }
                 callback();
             });
             this.push(file);


### PR DESCRIPTION
If you set the 'quiet' option then the glue output is suppressed. However, gulp-sprite-glue still outputs the commands that it executes to the console.

This PR ensures that this information isn't output if the 'quiet' option is true, and results in an output like this:

![screenshot 2015-03-11 01](https://cloud.githubusercontent.com/assets/632362/6597313/b38bc766-c7f3-11e4-8bdf-7ef245e16cef.png)
